### PR TITLE
Updated java version, dependencies and deprecated annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>7.0.0</project.curityVersion>
-        <project.slf4jVersion>1.7.32</project.slf4jVersion>
+        <project.slf4jVersion>1.7.36</project.slf4jVersion>
     </properties>
 
     <build>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.behaviosec.cloud</groupId>
             <artifactId>behaviocloud-java-sdk</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
@@ -73,9 +73,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>6.6.0</project.curityVersion>
+        <project.curityVersion>7.0.0</project.curityVersion>
         <project.slf4jVersion>1.7.32</project.slf4jVersion>
     </properties>
 
@@ -24,8 +24,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -69,7 +69,13 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.2.0.CR1</version>
+            <version>7.0.3.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/example/curity/authentication/RequestModel.java
+++ b/src/main/java/com/example/curity/authentication/RequestModel.java
@@ -16,7 +16,7 @@
 package com.example.curity.authentication;
 
 import jakarta.validation.Valid;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import se.curity.identityserver.sdk.Nullable;
 import se.curity.identityserver.sdk.web.Request;
 

--- a/src/main/java/com/example/curity/authentication/RequestModel.java
+++ b/src/main/java/com/example/curity/authentication/RequestModel.java
@@ -15,11 +15,11 @@
  */
 package com.example.curity.authentication;
 
-import org.hibernate.validator.constraints.NotBlank;
+import jakarta.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import se.curity.identityserver.sdk.Nullable;
 import se.curity.identityserver.sdk.web.Request;
 
-import javax.validation.Valid;
 import java.util.Optional;
 
 public final class RequestModel


### PR DESCRIPTION
Updated Java -> 17
Updated hibernate-validator -> 7.0.3.Final
Added javax.validation:validation-api as a dependancy to be able to replace the deprecated @NotBlank annotation